### PR TITLE
Update to 10.4.6

### DIFF
--- a/io.dbeaver.DBeaverCommunity.Client.mariadb.json
+++ b/io.dbeaver.DBeaverCommunity.Client.mariadb.json
@@ -31,7 +31,7 @@
             "x86_64"
           ],
           "url": "https://github.com/MariaDB/server.git",
-          "tag": "mariadb-10.3.15"
+          "tag": "mariadb-10.4.6"
         },
         {         
           "type": "file",


### PR DESCRIPTION
Update to the latest stable version of mariadb to ensure compatibility with 10.4.

A noticed change, although not really relevant to here as dbeaver uses the mysql binary, mariadb seems to create mariadb -> mysql symlinks now when building the client.