### PR TITLE
Updated to 10.11.7

### DIFF
--- a/io.dbeaver.DBeaverCommunity.Client.mariadb.json
+++ b/io.dbeaver.DBeaverCommunity.Client.mariadb.json
@@ -2,7 +2,7 @@
   "app-id": "io.dbeaver.DBeaverCommunity.Client.mariadb",
   "runtime": "io.dbeaver.DBeaverCommunity",
   "runtime-version": "stable",
-  "sdk": "org.freedesktop.Sdk//20.08",
+  "sdk": "org.freedesktop.Sdk//23.08",
   "build-extension": true,
   "separate-locales": false,
   "appstream-compose": false,
@@ -11,7 +11,10 @@
       "name": "mysql",
       "buildsystem": "cmake",
       "build-options": {
-        "strip": true
+        "strip": true,
+        "build-args": [
+          "--share=network"
+        ]
       },
       "config-opts": [
         "-DBUILD_CONFIG=mysql_release",
@@ -32,8 +35,8 @@
             "x86_64"
           ],
           "url": "https://github.com/MariaDB/server.git",
-          "tag": "mariadb-10.5.11",
-          "commit": "6dc46b5a4d8aa5432528745be3174267a9caa74d"
+          "tag": "mariadb-10.11.7",
+          "commit": "87e13722a95af5d9378d990caf48cb6874439347"
         },
         {         
           "type": "file",

--- a/io.dbeaver.DBeaverCommunity.Client.mariadb.json
+++ b/io.dbeaver.DBeaverCommunity.Client.mariadb.json
@@ -11,10 +11,7 @@
       "name": "mysql",
       "buildsystem": "cmake",
       "build-options": {
-        "strip": true,
-        "build-args": [
-          "--share=network"
-        ]
+        "strip": true
       },
       "config-opts": [
         "-DBUILD_CONFIG=mysql_release",
@@ -38,7 +35,19 @@
           "tag": "mariadb-10.11.7",
           "commit": "87e13722a95af5d9378d990caf48cb6874439347"
         },
-        {         
+        {
+          "type": "file",
+          "url": "https://github.com/fmtlib/fmt/archive/refs/tags/8.0.1.zip",
+          "sha256": "6747442c189064b857336007dd7fa3aaf58512aa1a0b2ba76bf1182eefb01025",
+          "dest": "extra/libfmt/src"
+        },
+        {
+          "type": "file",
+          "url": "https://github.com/PCRE2Project/pcre2/releases/download/pcre2-10.42/pcre2-10.42.zip",
+          "sha256": "0f2a1403733d1a409e9305996bf8e5ea7f69ed38f38d2bc1e0c0b041ad7a01a9",
+          "dest": "extra/pcre2/src"
+        },
+        {
           "type": "file",
           "path": "io.dbeaver.DBeaverCommunity.Client.mariadb.metainfo.xml"
         },

--- a/io.dbeaver.DBeaverCommunity.Client.mariadb.json
+++ b/io.dbeaver.DBeaverCommunity.Client.mariadb.json
@@ -33,7 +33,8 @@
           ],
           "url": "https://github.com/MariaDB/server.git",
           "tag": "mariadb-10.11.7",
-          "commit": "87e13722a95af5d9378d990caf48cb6874439347"
+          "commit": "87e13722a95af5d9378d990caf48cb6874439347",
+          "disable-shallow-clone": true
         },
         {
           "type": "file",

--- a/patches/pam.patch
+++ b/patches/pam.patch
@@ -2,13 +2,13 @@ diff --git a/cmake/build_configurations/mysql_release.cmake b/cmake/build_config
 index 37a6c459..e2a4ba8c 100644
 --- a/cmake/build_configurations/mysql_release.cmake
 +++ b/cmake/build_configurations/mysql_release.cmake
-@@ -124,7 +124,7 @@ ENDIF()
+@@ -147,7 +147,7 @@
  
  IF(UNIX)
    SET(WITH_EXTRA_CHARSETS all CACHE STRING "")
--  SET(PLUGIN_AUTH_PAM YES)
-+  SET(PLUGIN_AUTH_PAM NO)
+-  SET(PLUGIN_AUTH_PAM YES CACHE BOOL "")
++  SET(PLUGIN_AUTH_PAM NO CACHE BOOL "")
  
    IF(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-     IF(NOT IGNORE_AIO_CHECK)
+     FIND_PACKAGE(URING)
 


### PR DESCRIPTION
This PR serves as a base update for the MariaDB client. It updates the SDK from 20.08 to 23.08 and MariaDB from 10.5.11 to 10.11.7 (which is the most up to date LTS version). A future update for 11.x version will come later.